### PR TITLE
Fix sticky header and phone mockup identity labels

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box, Container, Typography } from '@mui/material';
+import LanguageSwitcher from './LanguageSwitcher';
+
+const Header: React.FC = () => {
+  return (
+    <Box sx={{ bgcolor: '#1a2a3a', py: 1, position: 'sticky', top: 0, zIndex: 1100 }}>
+      <Container maxWidth="lg">
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="subtitle1" sx={{ color: 'white', fontWeight: 700 }}>
+            Footeee
+          </Typography>
+          <LanguageSwitcher />
+        </Box>
+      </Container>
+    </Box>
+  );
+};
+
+export default Header;

--- a/src/components/mockups/MockupManagerDashboard.tsx
+++ b/src/components/mockups/MockupManagerDashboard.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Box, Typography, Chip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Settings, Home } from '@mui/icons-material';
+import PhoneFrame from './PhoneFrame';
+import { managerGames, recentActivity } from './mockupData';
+
+interface MockupManagerDashboardProps {
+  variant: 'games' | 'recent';
+}
+
+const MockupManagerDashboard: React.FC<MockupManagerDashboardProps> = ({ variant }) => {
+  const { t } = useTranslation();
+
+  const tabs = variant === 'games'
+    ? ['games', 'squads', 'players', 'venues']
+    : ['recent', 'games', 'squads', 'players'];
+
+  const activeTabLabel = variant === 'games' ? 'games' : 'recent';
+
+  return (
+    <PhoneFrame activeTab="manage">
+      {/* Top bar */}
+      <Box sx={{ bgcolor: '#4a9aa3', px: 1.5, py: 0.8, display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography sx={{ fontSize: 10, color: 'rgba(255,255,255,0.7)' }}>←</Typography>
+        <Box sx={{ display: 'flex', gap: 0.8, flex: 1 }}>
+          <Box sx={{ width: 14, height: 14, borderRadius: '50%', bgcolor: '#e6ac74' }} />
+          <Box sx={{ width: 14, height: 14, borderRadius: '50%', bgcolor: '#4a9aa3', border: '1px solid rgba(255,255,255,0.3)' }} />
+        </Box>
+        <Typography sx={{ fontSize: 8, color: 'white' }}>Isaac · {t('roles.manager.title').toUpperCase()}</Typography>
+      </Box>
+
+      {/* Title section */}
+      <Box sx={{ px: 1.5, pt: 1, pb: 0.5 }}>
+        <Typography sx={{ fontSize: 16, fontWeight: 700, lineHeight: 1.2 }}>{t('mockup.manager.title')}</Typography>
+        <Typography sx={{ fontSize: 8, color: '#888', lineHeight: 1.4 }}>{t('mockup.manager.subtitle')}</Typography>
+      </Box>
+
+      {/* Stats */}
+      <Box sx={{ px: 1.5, pb: 0.8 }}>
+        <Box sx={{ display: 'flex', gap: 2, mb: 0.3 }}>
+          <Box>
+            <Typography sx={{ fontSize: 14, fontWeight: 700, lineHeight: 1 }}>{variant === 'games' ? 10 : 5}</Typography>
+            <Typography sx={{ fontSize: 7, color: '#888' }}>{t('mockup.manager.gamesManaged')}</Typography>
+          </Box>
+          <Box>
+            <Settings sx={{ fontSize: 10, color: '#999', position: 'absolute', right: 16 }} />
+            <Typography sx={{ fontSize: 14, fontWeight: 700, lineHeight: 1 }}>2</Typography>
+            <Typography sx={{ fontSize: 7, color: '#888' }}>{t('mockup.manager.squadsManaged')}</Typography>
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Box>
+            <Typography sx={{ fontSize: 7, color: '#888' }}>—</Typography>
+            <Typography sx={{ fontSize: 7, color: '#888' }}>{t('mockup.manager.playersInSquads')}</Typography>
+          </Box>
+          <Box>
+            <Typography sx={{ fontSize: 7, color: '#888' }}>—</Typography>
+            <Typography sx={{ fontSize: 7, color: '#888' }}>{t('mockup.manager.upcoming')}</Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Tab bar */}
+      <Box sx={{ display: 'flex', gap: 0.5, px: 1.5, mb: 0.8 }}>
+        {tabs.map((tab) => (
+          <Chip
+            key={tab}
+            label={t(`mockup.nav.${tab === 'recent' ? 'recent' : tab}`)}
+            size="small"
+            sx={{
+              height: 18,
+              fontSize: 7,
+              bgcolor: tab === activeTabLabel ? '#4a9aa3' : 'transparent',
+              color: tab === activeTabLabel ? 'white' : '#666',
+              border: tab === activeTabLabel ? 'none' : '1px solid #ddd',
+              '& .MuiChip-label': { px: 0.6 },
+            }}
+          />
+        ))}
+      </Box>
+
+      {/* Content */}
+      <Box sx={{ flex: 1, overflow: 'hidden', px: 1 }}>
+        {variant === 'games' ? (
+          managerGames.slice(0, 4).map((game, i) => (
+            <Box
+              key={i}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                py: 0.6,
+                px: 0.8,
+                mb: 0.5,
+                border: '1px solid #e0e0e0',
+                borderRadius: 2,
+              }}
+            >
+              <Box sx={{ width: 24, height: 24, borderRadius: '50%', border: '2px solid #4a9aa3', display: 'flex', alignItems: 'center', justifyContent: 'center', mr: 0.8, flexShrink: 0 }}>
+                <Home sx={{ fontSize: 10, color: '#4a9aa3' }} />
+              </Box>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography sx={{ fontSize: 9, fontWeight: 600, lineHeight: 1.2 }}>{game.venue}</Typography>
+                <Typography sx={{ fontSize: 7, color: '#888', lineHeight: 1.2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {t(`mockup.time.${game.dayKey}`)} {t('mockup.time.at')} {game.time} · {game.players}
+                </Typography>
+              </Box>
+            </Box>
+          ))
+        ) : (
+          <>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5, px: 0.5 }}>
+              <Typography sx={{ fontSize: 10, fontWeight: 600 }}>{t('mockup.nav.recent')}</Typography>
+              <Typography sx={{ fontSize: 7, color: '#888' }}>7 {t('mockup.time.days')}</Typography>
+            </Box>
+            {recentActivity.map((activity, i) => (
+              <Box key={i} sx={{ py: 0.6, px: 0.5 }}>
+                <Typography sx={{ fontSize: 9, fontWeight: 600, lineHeight: 1.3 }}>
+                  {t('mockup.manager.joinedGame', { name: activity.name })}
+                </Typography>
+                <Typography sx={{ fontSize: 7, color: '#888', lineHeight: 1.2 }}>
+                  {activity.venue}
+                </Typography>
+              </Box>
+            ))}
+          </>
+        )}
+      </Box>
+    </PhoneFrame>
+  );
+};
+
+export default MockupManagerDashboard;

--- a/src/components/mockups/MockupPlayerDetail.tsx
+++ b/src/components/mockups/MockupPlayerDetail.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Box, Typography, Chip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Person } from '@mui/icons-material';
+import PhoneFrame from './PhoneFrame';
+import { squadNames, playerGames } from './mockupData';
+
+const MockupPlayerDetail: React.FC = () => {
+  const { t } = useTranslation();
+
+  const squadColors = ['#4a9aa3', '#4a9aa3', '#4a9aa3'];
+
+  return (
+    <PhoneFrame activeTab="players">
+      {/* Top bar */}
+      <Box sx={{ bgcolor: '#4a9aa3', px: 1.5, py: 0.8, display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography sx={{ fontSize: 10, color: 'rgba(255,255,255,0.7)' }}>←</Typography>
+        <Box sx={{ display: 'flex', gap: 0.8, flex: 1 }}>
+          <Box sx={{ width: 14, height: 14, borderRadius: '50%', bgcolor: '#e6ac74' }} />
+          <Box sx={{ width: 14, height: 14, borderRadius: '50%', bgcolor: '#4a9aa3', border: '1px solid rgba(255,255,255,0.3)' }} />
+        </Box>
+        <Typography sx={{ fontSize: 8, color: 'white' }}>Faisal · {t('roles.player.title').toUpperCase()}</Typography>
+      </Box>
+
+      {/* Player info */}
+      <Box sx={{ px: 1.5, pt: 1.5, pb: 0.8 }}>
+        <Typography sx={{ fontSize: 16, fontWeight: 700, lineHeight: 1.2 }}>Ijaz</Typography>
+        <Typography sx={{ fontSize: 8, color: '#888', lineHeight: 1.4 }}>Gogs</Typography>
+        <Typography sx={{ fontSize: 8, color: '#888', lineHeight: 1.4 }}>ijaz@spaceman.net</Typography>
+      </Box>
+
+      {/* Squads section */}
+      <Box sx={{ px: 1.5, pb: 0.8, borderTop: '1px solid #eee', pt: 0.8 }}>
+        <Typography sx={{ fontSize: 10, fontWeight: 600, mb: 0.5 }}>
+          {t('mockup.player.squadsCount', { count: squadNames.length })}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 0.4, flexWrap: 'wrap' }}>
+          {squadNames.map((squad, i) => (
+            <Chip
+              key={i}
+              icon={<Person sx={{ fontSize: 10, color: 'white !important' }} />}
+              label={`${squad.name} · ${squad.count}`}
+              size="small"
+              sx={{
+                height: 18,
+                fontSize: 7,
+                bgcolor: squadColors[i],
+                color: 'white',
+                '& .MuiChip-label': { px: 0.5 },
+                '& .MuiChip-icon': { ml: 0.3 },
+              }}
+            />
+          ))}
+        </Box>
+      </Box>
+
+      {/* Upcoming Games */}
+      <Box sx={{ flex: 1, overflow: 'hidden', px: 1, borderTop: '1px solid #eee', pt: 0.8 }}>
+        <Typography sx={{ fontSize: 10, fontWeight: 600, mb: 0.5, px: 0.5 }}>
+          {t('mockup.player.upcomingGamesCount', { count: playerGames.length })}
+        </Typography>
+        {playerGames.map((game, i) => (
+          <Box
+            key={i}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              py: 0.6,
+              px: 0.8,
+              mb: 0.5,
+              border: '2px solid #4a9aa3',
+              borderRadius: 2,
+            }}
+          >
+            <Box sx={{ width: 24, height: 24, borderRadius: '50%', bgcolor: '#ddd', display: 'flex', alignItems: 'center', justifyContent: 'center', mr: 0.8, flexShrink: 0 }}>
+              <Person sx={{ fontSize: 12, color: '#888' }} />
+            </Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography sx={{ fontSize: 9, fontWeight: 600, lineHeight: 1.2 }}>{game.venue}</Typography>
+              <Typography sx={{ fontSize: 7, color: '#888', lineHeight: 1.2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {t(`mockup.time.${game.dayKey}`)} {t('mockup.time.at')} {game.time} · {game.players}
+              </Typography>
+            </Box>
+            <Chip
+              label={t('mockup.player.left', { count: game.left })}
+              size="small"
+              sx={{
+                height: 18,
+                fontSize: 7,
+                bgcolor: '#4a9aa3',
+                color: 'white',
+                '& .MuiChip-label': { px: 0.5 },
+                flexShrink: 0,
+              }}
+            />
+          </Box>
+        ))}
+      </Box>
+    </PhoneFrame>
+  );
+};
+
+export default MockupPlayerDetail;


### PR DESCRIPTION
## Summary
- Made header bar sticky (`position: sticky`) so it stays visible on all viewports (mobile, tablet, desktop)
- Fixed player mockup (middle phone) header identity: now shows "Faisal · Player" instead of "Isaac · MANAGER"
- Added missing manager mockup (right phone) header identity: now shows "Isaac · Manager"
- Role labels in mockup headers use i18n translation keys for automatic localization

Closes #1

## Test plan
- [ ] Verify header stays fixed at top when scrolling on mobile, tablet, and desktop viewports
- [ ] Verify middle phone mockup shows "Faisal · PLAYER" in its header bar
- [ ] Verify right phone mockup shows "Isaac · MANAGER" in its header bar
- [ ] Switch language and verify mockup role labels translate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)